### PR TITLE
Typo fix

### DIFF
--- a/source/01-LE/02.ptx
+++ b/source/01-LE/02.ptx
@@ -431,7 +431,7 @@ A matrix is in <term>reduced row echelon form</term> (<term>RREF</term>)<idx>Red
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> Each term above or below a pivot is zero.
+<li> Each term above and below a pivot is zero.
 </li>
 <li> All rows of zeroes are at the bottom of the matrix.
 </li>

--- a/source/01-LE/02.ptx
+++ b/source/01-LE/02.ptx
@@ -431,7 +431,7 @@ A matrix is in <term>reduced row echelon form</term> (<term>RREF</term>)<idx>Red
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> Each term above and below a pivot is zero.
+<li> All terms in each pivot column, besides the pivot itself, are zero.
 </li>
 <li> All rows of zeroes are at the bottom of the matrix.
 </li>
@@ -453,7 +453,7 @@ Recall that a matrix is in <term>reduced row echelon form</term> (<term>RREF</te
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> Each term above and below a pivot is zero.
+<li> All terms in each pivot column, besides the pivot itself, are zero.
 </li>
 <li> All rows of zeroes are at the bottom of the matrix.
 </li>

--- a/source/01-LE/02.ptx
+++ b/source/01-LE/02.ptx
@@ -453,7 +453,7 @@ Recall that a matrix is in <term>reduced row echelon form</term> (<term>RREF</te
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> Each term above or below a pivot is zero.
+<li> Each term above and below a pivot is zero.
 </li>
 <li> All rows of zeroes are at the bottom of the matrix.
 </li>

--- a/source/01-LE/02.ptx
+++ b/source/01-LE/02.ptx
@@ -426,14 +426,14 @@ matrix to the next:
 A matrix is in <term>reduced row echelon form</term> (<term>RREF</term>)<idx>Reduced row echelon form</idx> if
         </p>
 <ol>
-<li> The leading term (first nonzero term) of each nonzero row is a 1.
-      Call these terms <term>pivots</term>.<idx>pivot</idx>
+<li> The leftmost nonzero term of each row is 1.
+      We call these terms <term>pivots</term>.<idx>pivot</idx>
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> All terms in each pivot column, besides the pivot itself, are zero.
+<li> Each term that is either above or below a pivot is 0.
 </li>
-<li> All rows of zeroes are at the bottom of the matrix.
+<li> All zero rows (rows whose terms are all 0) are at the bottom of the matrix.
 </li>
 </ol>
     <p>
@@ -448,14 +448,14 @@ Every matrix has a unique reduced row echelon form. If <m>A</m> is a matrix, we 
 Recall that a matrix is in <term>reduced row echelon form</term> (<term>RREF</term>) if
         </p>
 <ol>
-<li> The leading term (first nonzero term) of each nonzero row is a 1.
-      Call these terms <term>pivots</term>.
+<li> The leftmost nonzero term of each row is 1.
+      We call these terms <term>pivots</term>.
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> All terms in each pivot column, besides the pivot itself, are zero.
+<li> Each term that is either above or below a pivot is 0.
 </li>
-<li> All rows of zeroes are at the bottom of the matrix.
+<li> All zero rows (rows whose terms are all 0) are at the bottom of the matrix.
 </li>
 </ol>
     <p>
@@ -476,14 +476,14 @@ For the ones not in RREF, determine which rule is violated and how it might be f
 Recall that a matrix is in <term>reduced row echelon form</term> (<term>RREF</term>) if
         </p>
 <ol>
-<li> The leading term (first nonzero term) of each nonzero row is a 1.
-      Call these terms <term>pivots</term>.
+<li> The leftmost nonzero term of each row is 1.
+      We call these terms <term>pivots</term>.
 </li>
 <li> Each pivot is to the right of every higher pivot.
 </li>
-<li> Each term above or below a pivot is zero.
+<li> Each term that is either above or below a pivot is 0.
 </li>
-<li> All rows of zeroes are at the bottom of the matrix.
+<li> All zero rows (rows whose terms are all 0) are at the bottom of the matrix.
 </li>
 </ol>
     <p>


### PR DESCRIPTION
Jared Bunn pointed out in Slack that to be precisely correct, we should say "Each term above and below a pivot is zero", rather than "Each term above or below a pivot is zero".