### PR TITLE
Typo fix

### DIFF
--- a/source/02-EV/01.ptx
+++ b/source/02-EV/01.ptx
@@ -326,7 +326,7 @@ The following are all equivalent statements:
           </task>
           <task>
             <statement>
-              <p> Since your statement was true, use the solution set to describe a linear combination of <m>\left[\begin{array}{c} 1 \\ 0 \\ 2 \end{array}\right] , \left[\begin{array}{c} 3 \\ 0 \\ 6 \end{array}\right] , \left[\begin{array}{c} 2 \\ 0 \\ 4 \end{array}\right] , \text{ and } \left[\begin{array}{c} -4 \\ 1 \\ -5 \end{array}\right]</m> that equals <m>\left[\begin{array}{c} -5 \\ -1 \\ -7 \end{array}\right]</m>. </p>
+              <p> Since your statement was true, use the solution set to describe a linear combination of <m>\left[\begin{array}{c} 1 \\ 0 \\ 2 \end{array}\right] , \left[\begin{array}{c} 3 \\ 0 \\ 6 \end{array}\right] , \left[\begin{array}{c} 2 \\ 0 \\ 4 \end{array}\right] , \text{ and } \left[\begin{array}{c} -4 \\ 1 \\ -5 \end{array}\right]</m> that equals <m>\left[\begin{array}{c} -6 \\ 2 \\ -6 \end{array}\right]</m>. </p>
             </statement>
           </task>
         <!-- <answer>


### PR DESCRIPTION
Fix typo reported by Jared Bunn in Slack with Activity 2.1.10 part (c)

[Activity 2.1.10](https://teambasedinquirylearning.github.io/linear-algebra/2023/EV1.html#activity-31) 
https://teambasedinquirylearning.github.io/linear-algebra/2023/EV1.html#activity-31

Vector in part (c) should match vector in part (a).  