### PR TITLE
Remove licensing info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ These materials are hosted at <http://linear.tbil.org>.
 Learn more at [TBIL.org](http://tbil.org) and join our community of instructors
 and contributors!
 
-## Copyright and Licensing
-
-See [source/meta/copyright.ptx](source/meta/copyright.ptx).
-
 ## Contributing
 
 Contributing guidelines are maintained in our organization [wiki](https://github.com/TeamBasedInquiryLearning/wiki/wiki).


### PR DESCRIPTION
Note that GitHub has a standard place to find a project's license if it's named e.g. LICENSE.md like ours is:

![image](https://github.com/TeamBasedInquiryLearning/linear-algebra/assets/1559632/851bce10-2c4e-4df5-89a1-6a99bc523225)
