### PR TITLE
Separate publication file for slides and print

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -7,7 +7,7 @@
     <target name="print" format="pdf" output-filename="TBIL-LA-2024.pdf" deploy-dir="2024/pdf">
       <stringparams debug.project.number="the-way-it-should-be"/>
     </target>
-    <target name="slides" format="pdf" xsl="slides.xsl" output-filename="TBIL-LA-2024-slides.pdf" deploy-dir="2024/pdf">
+    <target name="slides" format="pdf" xsl="slides.xsl" output-filename="TBIL-LA-2024-slides.pdf" deploy-dir="2024/pdf" publication="slides.ptx">
       <stringparams debug.project.number="the-way-it-should-be"/>
     </target>
     <!-- use `python scripts/bank/build.py` for this target -->

--- a/publication/slides.ptx
+++ b/publication/slides.ptx
@@ -39,7 +39,7 @@
     <!-- for printing; set @sides="two" if the printing woudl be two- -->
     <!-- sided.  The asymptote/@links set to "yes" would produce      -->
     <!-- links the html version of asymptote graphics.                -->
-  <latex print="no" sides="one" font-size="12">
+  <latex print="no" sides="one" font-size="14">
     <asymptote links="no"/>
     <page>
       <geometry>letterpaper,margin=1in</geometry>


### PR DESCRIPTION
I put the printed PDF font size at 12, I think that looks good, and kept the slides at 14.  

Please verify that both print and slides build appropriately for you as well.

Closes #262 