### PR TITLE
remove non-singular in a couple places

### DIFF
--- a/source/04-MX/02.ptx
+++ b/source/04-MX/02.ptx
@@ -280,7 +280,6 @@ Is the matrix <m>\left[\begin{array}{ccc} 2 &amp; 3 &amp; 1 \\ -1 &amp; -4 &amp;
     <statement>
         Assume <m>A</m> is an <m>n \times n</m> matrix. Prove the following are equivalent. Some of these results you have proven previously.
         <ul>
-<li> <m>A</m> is non-singular.</li>
 <li> <m>A</m> row reduces to the identity matrix.</li>
 <li> For any choice of <m>\vec{b} \in \mathbb{R}^n</m>, the system of equations represented by the augmented matrix <m>[A|\vec{b}]</m> has a unique solution.</li>
 <li> The columns of <m>A</m> are a linearly independent set.</li>

--- a/source/04-MX/03.ptx
+++ b/source/04-MX/03.ptx
@@ -170,7 +170,7 @@ Video coming soon to
          </exploration>
 
 <exploration>
-            <statement>If <m>A</m> is nonsingular and square, and both <m>P</m> and <m>Q</m> are nonsingular, with <m>PAQ = I</m>, prove that <m>A^{-1} = QP</m>.
+            <statement>Prove that if <m>A</m>, <m>P</m>, and <m>Q</m> are invertible with <m>PAQ = I</m>, then <m>A^{-1} = QP</m>.
              </statement>
          </exploration>
     </subsection>


### PR DESCRIPTION
Brought up in #284 by @owensks.

@jford1906 let me know what you think. You defined "non-singular" in EV7 to mean `[A|b]` has a unique solution, so I left that as-is. But for better portibility of the other explorations I switched to use "invertible".