### PR TITLE
Remove randrange from lambda

### DIFF
--- a/exercises/outcomes/AT/AT5/generator.sage
+++ b/exercises/outcomes/AT/AT5/generator.sage
@@ -25,7 +25,9 @@ class Generator(BaseGenerator):
 
         n = randrange(6)
         if n==0:
-            plus = lambda v1,v2 : vector([randrange(2,5)*v1[0]+v2[0], v1[1]+randrange(1,4)*v2[1]])
+            m1=randrange(2,5)
+            m2=randrange(1,4)
+            plus = lambda v1,v2, m1=m1, m2=m2 : vector([m1*v1[0]+v2[0], v1[1]+m2*v2[1]])
             times = lambda c,v : vector([c*v[0],c*v[1]])
             a=randrange(1,8)
             b=randrange(1,8)

--- a/exercises/outcomes/AT/AT5/generator.sage
+++ b/exercises/outcomes/AT/AT5/generator.sage
@@ -27,12 +27,12 @@ class Generator(BaseGenerator):
         if n==0:
             m1=randrange(2,5)
             m2=randrange(1,4)
-            plus = lambda v1,v2, m1=m1, m2=m2 : vector([m1*v1[0]+v2[0], v1[1]+m2*v2[1]])
+            plus = lambda v1,v2: vector([m1*v1[0]+v2[0], v1[1]+m2*v2[1]])
             times = lambda c,v : vector([c*v[0],c*v[1]])
             a=randrange(1,8)
             b=randrange(1,8)
-            theta = lambda v,a=a : vector([v[0]+a,v[1]+b])
-            untheta = lambda v,a=a : vector([v[0]-a,v[1]-b])
+            theta = lambda v : vector([v[0]+a,v[1]+b])
+            untheta = lambda v : vector([v[0]-a,v[1]-b])
 
             trueproperty = choice(["dist_v"])
             falseproperties=[
@@ -47,8 +47,8 @@ class Generator(BaseGenerator):
             r2 = randrange(1,9)
             times= lambda c,v : vector([c*v[0]+r1*c*v[1],r2*c*v[1]])
             a=randrange(1,8)
-            theta = lambda v,a=a : vector([v[0],v[1]+a])
-            untheta = lambda v,a=a : vector([v[0],v[1]-a])
+            theta = lambda v : vector([v[0],v[1]+a])
+            untheta = lambda v : vector([v[0],v[1]-a])
 
             trueproperty=choice(["dist_v","dist_s"])
             falseproperties=[
@@ -62,8 +62,8 @@ class Generator(BaseGenerator):
             times= lambda c,v : vector([c*v[0],c^(r2)*v[1]])
             a=randrange(1,8)
             b=randrange(2,8)
-            theta = lambda v,a=a : vector([v[0]+b*v[1],v[1]+a])
-            untheta = lambda v,a=a : vector([v[0]-b*(v[1]-a),v[1]-a])
+            theta = lambda v: vector([v[0]+b*v[1],v[1]+a])
+            untheta = lambda v : vector([v[0]-b*(v[1]-a),v[1]-a])
 
             trueproperty=choice(["mul_assoc","mul_id","dist_v"])
             falseproperties=[
@@ -75,8 +75,8 @@ class Generator(BaseGenerator):
             plus = lambda v1,v2 : vector([v1[0]+v2[0], v1[1]+v2[1]-r1])
             times= lambda c,v : vector([c*v[0],c*v[1]])
             a=randrange(1,5)
-            theta = lambda v,a=a : vector([v[0],v[1]+a*v[0]^2])
-            untheta = lambda v,a=a : vector([v[0],v[1]-a*v[0]^2])
+            theta = lambda v: vector([v[0],v[1]+a*v[0]^2])
+            untheta = lambda v : vector([v[0],v[1]-a*v[0]^2])
 
             trueproperty=choice(["add_assoc"])
             falseproperties=[
@@ -87,11 +87,11 @@ class Generator(BaseGenerator):
         elif n==4:
             r=randrange(3,8)
             plus = lambda v1,v2 : vector([v1[0]+v2[0], v1[1]+v2[1]])
-            times= lambda c,v,r=r : vector([c*v[0],c*v[1]-r*c+r])            
+            times= lambda c,v : vector([c*v[0],c*v[1]-r*c+r])            
             a=randrange(1,5)
             b=randrange(1,5)
-            theta = lambda v,a=a,b=b : vector([v[0]+b,v[1]+a*v[0]])
-            untheta = lambda v,a=a,b=b : vector([v[0]-b,v[1]-a*(v[0]-b)])
+            theta = lambda v : vector([v[0]+b,v[1]+a*v[0]])
+            untheta = lambda v : vector([v[0]-b,v[1]-a*(v[0]-b)])
 
             trueproperty=choice(["mul_assoc"])
             falseproperties=[
@@ -101,13 +101,13 @@ class Generator(BaseGenerator):
 
         elif n==5:
             r=randrange(1,6)
-            plus = lambda v1,v2,r=r : vector([v1[0]+v2[0]+r, v1[1]+v2[1]])
+            plus = lambda v1,v2 : vector([v1[0]+v2[0]+r, v1[1]+v2[1]])
             r1 = randrange(1,6)
             r2 = randrange(1,6)
-            times= lambda c,v,r=r : vector([c*v[0]+r1*c*v[1]-r,r2*c*v[1]])
+            times= lambda c,v,: vector([c*v[0]+r1*c*v[1]-r,r2*c*v[1]])
             a=randrange(1,5)
-            theta = lambda v,a=a : vector([v[0],v[1]+a*v[0]])
-            untheta = lambda v,a=a : vector([v[0],v[1]-a*v[0]])
+            theta = lambda v: vector([v[0],v[1]+a*v[0]])
+            untheta = lambda v : vector([v[0],v[1]-a*v[0]])
 
             trueproperty=choice(["add_assoc","dist_v","dist_s"])
             falseproperties=[


### PR DESCRIPTION
Closes #305.  The randranges inside of the lambda defining the addition in this case were called each time the oplus function was called, generating different results each time.  To achieve the desired behavior, one should call the randranges (and any other randomization) prior to defining the lambda.

This was done correctly in the other cases, so that's why the bug was isolated to the n==0 case.