### PR TITLE
tweak to ev3 activity for single-response

### DIFF
--- a/source/02-EV/03.ptx
+++ b/source/02-EV/03.ptx
@@ -22,7 +22,9 @@
     <activity>
         <statement>
             <p>
-        Let <m>S</m> denote a set of vectors in <m>\IR^n</m> and suppose that <m>\vec{u},\vec{v}\in\vspan(S)</m>, <m>c\in\IR</m> and that <m>\vec{w}\in\IR^n</m>. Which of the following vectors must belong to <m>\vspan(S)</m>?
+        Let <m>S</m> denote a set of vectors in <m>\IR^n</m> and suppose that <m>\vec{u},\vec{v}\in\vspan(S)</m>, 
+        <m>c\in\IR</m> and that <m>\vec{w}\in\IR^n</m>. Which of the following vectors might
+        <em>not</em> belong to <m>\vspan(S)</m>?
         <ol marker="A.">
           <li><m>\vec{0}</m></li>
           <li><m>\vec{u}+\vec{w}</m></li>


### PR DESCRIPTION
Proposed tweak to one of the changes in #336 

In particular, I think every other MCQ in the book is written to have a single answer, to support multiple response mechanisms such as A/B/C/D flashcards, Zoom polls, etc., which may only support a single letter choice. This tweak updates this activity to match.