### PR TITLE
Tweak RREF nonexample in LE2

### DIFF
--- a/source/01-LE/02.ptx
+++ b/source/01-LE/02.ptx
@@ -491,7 +491,7 @@ For the ones not in RREF, determine which rule is violated and how it might be f
     </p>
       <sidebyside widths="33% 33% 33%">
 <p><me> A=\left[\begin{array}{ccc|c} 1 &amp; 0 &amp; 0 &amp; 3 \\ 0 &amp; 0 &amp; 1 &amp; -1 \\ 0 &amp; 0 &amp; 0 &amp; 0 \end{array}\right]</me></p>
-<p><me> B=\left[\begin{array}{ccc|c} 1 &amp; 2 &amp; 4 &amp; 3 \\ 0 &amp; 0 &amp; 1 &amp; -1 \\ 0 &amp; 0 &amp; 0 &amp; 0 \end{array}\right]</me></p>
+<p><me> B=\left[\begin{array}{ccc|c} 1 &amp; 0 &amp; 4 &amp; 3 \\ 0 &amp; 1 &amp; 0 &amp; -1 \\ 0 &amp; 0 &amp; 1 &amp; 2 \end{array}\right]</me></p>
 <p><me> C=\left[\begin{array}{ccc|c} 0 &amp; 0 &amp; 0 &amp; 0 \\ 1 &amp; 2 &amp; 0 &amp; 3 \\ 0 &amp; 0 &amp; 1 &amp; -1  \end{array}\right]</me></p>
         </sidebyside>
     </statement>


### PR DESCRIPTION
Closes #350 by changing an example to have a nonzero above, but not adjacent to, a pivot.