### PR TITLE
Add backreferences into 3.3.11, closes #360

### DIFF
--- a/source/02-EV/06.ptx
+++ b/source/02-EV/06.ptx
@@ -72,7 +72,7 @@ What would be the result of removing the vector that gave us this column?
         </p>
   </statement>
 </definition>
-<observation>
+<observation xml:id="observation-subspace-basis">
         <p>
   So given a set <m>S=\{\vec v_1,\dots,\vec v_m\}</m>,
   to compute a basis for the subspace <m>\vspan S</m>,

--- a/source/02-EV/07.ptx
+++ b/source/02-EV/07.ptx
@@ -184,7 +184,7 @@ used in this span?
 <sage language="octave">
 </sage>
 
-<fact>
+<fact xml:id="fact-solution-space-basis">
     <statement>
     <p>
   The coefficients of the free variables in the solution space of a linear system

--- a/source/03-AT/03.ptx
+++ b/source/03-AT/03.ptx
@@ -435,14 +435,14 @@ Let  <m>T:\IR^n\to\IR^m</m> be a linear transformation with standard matrix <m>A
     <p>
     The kernel of <m>T</m> is the solution set of the homogeneous system given
 by the augmented matrix <m>\left[\begin{array}{c|c}A&amp;\vec 0\end{array}\right]</m>.
-Use the coefficients of its free variables to get a basis for the kernel.
+Use the coefficients of its free variables to get a basis for the kernel (as in <xref ref="fact-solution-space-basis"/>).
     </p>
 </li>
 <li>
     <p>
     The image of <m>T</m> is the span of the columns of <m>A</m>. Remove
 the vectors creating non-pivot columns in <m>\RREF A</m> to get a basis
-for the image.
+for the image (as in <xref ref="observation-subspace-basis"/>).
     </p>
 </li>
 </ul>


### PR DESCRIPTION
Needed to add `<xml:id>`s into the previous sections, and then added references to them within [Fact 3.3.11](https://teambasedinquirylearning.github.io/linear-algebra/2024e/AT3.html#fact-13) to address #360.