### PR TITLE
various edits to warmups and cooldowns

### DIFF
--- a/source/02-EV/02.ptx
+++ b/source/02-EV/02.ptx
@@ -10,7 +10,6 @@
     </objectives>
 
     <subsection>
-        <!-- I'm thinking for this warmup, I mostly want students to recall the definition of a linear combination of vectors and the span of a set. -->
         <title>Warm Up</title>
         <activity xml:id="EV2-Analogy">
             <introduction>

--- a/source/02-EV/03.ptx
+++ b/source/02-EV/03.ptx
@@ -807,12 +807,11 @@ Let <m>W</m> be a subspace of a vector space <m>V</m>.  How are <m>\vspan W</m> 
 
     <subsection>
         <title>Cool Down</title>
+        <remark>
+            Recall that in <xref ref="EV2-Analogy"/> we used the words <em>vector</em>, <em>linear combination</em>, and <em>span</em> to make an anology with recipes, ingredients, and meals.
+            In this analogy, a <em>recipe</em> was defined to be a list of amounts of each ingredient to build a particular meal.
+        </remark>
         <activity>
-            <introduction>
-                <p>
-                    In Warm Up <xref ref="EV2-Analogy"/> we used the words <em>vector</em>, <em>linear combination</em>, and <em>span</em> to make an anology with recipes, ingredients, and meals. 
-                </p>
-            </introduction>
             <task>
                 <statement>
                     <p>

--- a/source/02-EV/04.ptx
+++ b/source/02-EV/04.ptx
@@ -476,15 +476,19 @@ vectors that can form a linearly independent set?
 </subsection>
 <subsection>
     <title>Cool Down</title>
+    <remark>
+        Recall that in <xref ref="EV2-Analogy"/> we used the words <em>vector</em>, <em>linear combination</em>, and <em>span</em> to make an anology with recipes, ingredients, and meals.
+        In this analogy, a <em>recipe</em> was defined to be a list of amounts of each ingredient to build a particular meal.
+    </remark>
     <activity>
-        <task>
             <statement>
                 <p>
                     Consider the statement: The set of vectors <m>\left\{\vec{v}_1,\vec{v}_2,\vec{v}_3\right\}</m> is linearly independent because the vector <m>\vec{v}_3</m> is a linear combination of <m>\vec{v_1}</m> and <m>\vec{v}_2</m>. 
                     Construct an analogous statement involving ingredients, meals, and recipes, using the terms <em>linearly independent</em> and <em>linear combination</em>.
                 </p>
             </statement>
-        </task>
+    </activity>
+    <activity>
         <task>
             <statement>
                 <p>

--- a/source/02-EV/04.ptx
+++ b/source/02-EV/04.ptx
@@ -489,6 +489,11 @@ vectors that can form a linearly independent set?
             </statement>
     </activity>
     <activity>
+        <introduction>
+            <p>
+                The following exercises are designed to help develop your geometric intution around linear dependence.
+            </p>
+        </introduction>
         <task>
             <statement>
                 <p>

--- a/source/02-EV/05.ptx
+++ b/source/02-EV/05.ptx
@@ -12,6 +12,10 @@
 
     <subsection>
         <title>Warm Up</title>
+        <remark>
+            Recall that in <xref ref="EV2-Analogy"/> we used the words <em>vector</em>, <em>linear combination</em>, and <em>span</em> to make an anology with recipes, ingredients, and meals.
+            In this analogy, a <em>recipe</em> was defined to be a list of amounts of each ingredient to build a particular meal.
+        </remark>
         <activity>
             <introduction>
                 <p>


### PR DESCRIPTION
addresses comments in #374 for easier cross-referencing for analogies. 

I opted to splice in a remark at the beginning of each warmup or cooldown in which the analogy is revisited. The remark links to the original warmup but also reminds the reader right there what the terms mean.